### PR TITLE
inventory: Remove deprecated characters from group name

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,7 +1,7 @@
 [workstation]
 127.0.0.1 ansible_connection=local
 
-[servers-centos]
+[servers_centos]
 estrella.justinwflory.com
 horizon.justinwflory.com
 irc-lug.rit.edu

--- a/playbooks/centos-server.yml
+++ b/playbooks/centos-server.yml
@@ -1,6 +1,6 @@
 ---
 - name: set up Justin's preferred CentOS 7.x Server configuration
-  hosts: servers-centos
+  hosts: servers_centos
   become: yes
 
   roles:


### PR DESCRIPTION
This commit resolves a deprecation warning that comes from using invalid
characters in a group name in the inventory. Hyphens are a no-no, it
seems. So, I just changed it to an underscore.

Solves this warning specifically:

```
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set
to allow bad characters in group names by default, this will change, but
still be user configurable on deprecation. This feature will be removed
in version 2.10.

[WARNING]: Invalid characters were found in group names but not
replaced, use -vvvv to see details
```