### PR TITLE
inventory/vars: Add target_group variable

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 ansible_python_interpreter: /usr/bin/python3
+target_group: jflory
 target_user: jflory
 target_user_name: Justin W. Flory
 user_home_dir: /home/jflory


### PR DESCRIPTION
This commit adds `target_group` as a new variable in the global
environment. This is intended to correspond with environments where I
may want these two values to be different, like they were at one of my
previous employers with a RHEL 7 environment.

This does not change all places where I reference `group`, but it puts
the variable in existence so I can start writing new roles correctly,
and migrate the others later.