### PR TITLE
system/fedora: Change docker -> moby-engine

### DIFF
--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -49,7 +49,6 @@
       - cherrytree
       - chromaprint-tools
       - cmus
-      - docker
       - docker-compose
       - duply
       - epiphany
@@ -77,6 +76,7 @@
       - libvirt
       - libvirt-devel
       - meld
+      - moby-engine
       - mpris-scrobbler
       - mpv
       - nautilus-dropbox


### PR DESCRIPTION
This commit drops the `docker` package from my default package list and
exchanges it with the `moby-engine` package. This is the updated Docker
run-time package, although why it was not gracefully migrated in the F31
upgrade, I don't know.

[Reference](https://fedoraproject.org/wiki/Bugs/Common#Docker_package_no_longer_available_and_will_not_run_by_default_.28due_to_switch_to_cgroups_v2.29)