### PR TITLE
roles: Add new sublime-text role (closes #19)

### DIFF
--- a/playbooks/fedora-workstation.yml
+++ b/playbooks/fedora-workstation.yml
@@ -17,6 +17,7 @@
     - { role: apps/powerline-go, tags: ['powerline', 'apps'] }
     - { role: apps/slack, tags: ['slack', 'desktop', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'apps'] }
+    - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }
     - { role: apps/task, tags: ['task', 'apps'] }
     - { role: apps/thunderbird, tags: ['thunderbird', 'desktop', 'apps'] }
     - { role: apps/tmux, tags: ['tmux', 'apps'] }

--- a/playbooks/rhel-workstation.yml
+++ b/playbooks/rhel-workstation.yml
@@ -15,6 +15,7 @@
     - { role: apps/npm, tags: ['npm', 'apps'] }
     - { role: apps/powerline-go, tags: ['powerline', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'apps'] }
+    - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }
     - { role: apps/task, tags: ['task', 'apps'] }
     # - { role: apps/thunderbird, tags: ['thunderbird', 'apps'] }
     - { role: apps/tmux, tags: ['tmux', 'apps'] }

--- a/roles/apps/sublime-text/files/Anaconda.sublime-settings
+++ b/roles/apps/sublime-text/files/Anaconda.sublime-settings
@@ -1,0 +1,8 @@
+{
+    "anaconda_linter_mark_style": "squiggly_underline",
+    "pep8_ignore":
+    [
+        "W503"
+    ],
+    "pep8_max_line_length": 88,
+}

--- a/roles/apps/sublime-text/files/Markdown.sublime-settings
+++ b/roles/apps/sublime-text/files/Markdown.sublime-settings
@@ -1,0 +1,15 @@
+// These settings override both User and Default settings for the Markdown syntax
+{
+    // set vertical rulers in specified columns.
+    // Use "rulers": [80] for just one ruler
+    // default value is []
+    "rulers": [80],
+
+    // turn on word wrap for source and text
+    // default value is "auto", which means off for source and on for text
+    "word_wrap": "auto",
+
+    // set word wrapping at this column
+    // default value is 0, meaning wrapping occurs at window width
+    "wrap_width": 0
+}

--- a/roles/apps/sublime-text/files/Package Control.sublime-settings
+++ b/roles/apps/sublime-text/files/Package Control.sublime-settings
@@ -1,0 +1,15 @@
+{
+    "bootstrapped": true,
+    "in_process_packages":
+    [
+    ],
+    "installed_packages":
+    [
+        "Anaconda",
+        "GitGutter",
+        "Package Control",
+        "SideBarEnhancements",
+        "sublack",
+        "Theme - Flatland"
+    ]
+}

--- a/roles/apps/sublime-text/files/Preferences.sublime-settings
+++ b/roles/apps/sublime-text/files/Preferences.sublime-settings
@@ -1,0 +1,17 @@
+{
+	"added_words":
+	[
+		"justinwflory",
+		"playbook"
+	],
+	"color_scheme": "Packages/Theme - Flatland/Flatland Dark.tmTheme",
+	"ensure_newline_at_eof_on_save": true,
+	"font_size": 9,
+	"ignored_packages":
+	[
+		"Vintage"
+	],
+	"spell_check": true,
+	"theme": "Flatland Dark.sublime-theme",
+	"translate_tabs_to_spaces": true
+}

--- a/roles/apps/sublime-text/files/Python.sublime-settings
+++ b/roles/apps/sublime-text/files/Python.sublime-settings
@@ -1,0 +1,6 @@
+// These settings override both User and Default settings for the Python syntax
+{
+    // Columns in which to display vertical rulers
+    "rulers": [88],
+    "sublack.black_on_save": true
+}

--- a/roles/apps/sublime-text/tasks/main.yml
+++ b/roles/apps/sublime-text/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: import Sublime HQ RPM signing key
+  rpm_key:
+    key: "https://download.sublimetext.com/sublimehq-rpm-pub.gpg"
+    state: present
+
+- name: add Sublime Text repository
+  get_url:
+    dest: /etc/yum.repos.d/
+    url: "https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo"
+    owner: root
+    group: root
+    setype: system_conf_t
+    seuser: system_u
+    mode: 0644
+
+- name: install sublime-text package
+  package:
+    state: present
+    name: sublime-text
+
+- name: create user configuration directory
+  file:
+    state: directory
+    path: "{{ user_home_dir }}/.config/sublime-text-3/Packages/User"
+    owner: "{{ target_user }}"
+    group: "{{ target_group }}"
+    setype: config_home_t
+    seuser: system_u
+    mode: 0700
+
+- name: push sublime-settings files to user configuration directory
+  copy:
+    src: "{{ item }}"
+    dest: "{{ user_home_dir }}/.config/sublime-text-3/Packages/User/{{ item }}"
+    owner: "{{ target_user }}"
+    group: "{{ target_group }}"
+    setype: config_home_t
+    seuser: system_u
+    mode: 0644
+  loop:
+    - Anaconda.sublime-settings
+    - Markdown.sublime-settings
+    - Package Control.sublime-settings
+    - Preferences.sublime-settings
+    - Python.sublime-settings

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -2,7 +2,6 @@
 - name: import third-party repository signing keys
   rpm_key: key={{ item }} state=present
   loop:
-    - https://download.sublimetext.com/sublimehq-rpm-pub.gpg
     - https://negativo17.org/repos/RPM-GPG-KEY-slaanesh
 
 - name: add/upgrade RPM Fusion repositories
@@ -21,7 +20,6 @@
   loop:
     - https://negativo17.org/repos/fedora-flash-plugin.repo
     - https://negativo17.org/repos/fedora-spotify.repo
-    - https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
 
 - name: install base packages
   ### Package notes ###
@@ -99,7 +97,6 @@
       - smartmontools
       - spotify-client
       - strace
-      - sublime-text
       - telegram-desktop
       - typetype-molot-fonts
       - '@vagrant'


### PR DESCRIPTION
This commit creates a new role for Sublime Text 3, alongside the
assortment of other desktop apps currently installed in my environment.
This repo takes some commands out of my base/fedora-workstation role for
installing Sublime Text 3 and moves them into its own standalone role.
This makes it easier to install Sublime Text 3 with my Ansible Role
outside of Fedora environments.

A few things of note:

* All user sublime-settings files currently used are tracked as of now
* sublack integration added for Python
* Black is run on save for Python files

Tested on `fossbook`, but not yet tested on `ff`.

Closes #19.