### PR TITLE
sublime: Markdown and Python preference tweaks

### DIFF
--- a/roles/apps/sublime-text/files/Markdown.sublime-settings
+++ b/roles/apps/sublime-text/files/Markdown.sublime-settings
@@ -1,15 +1,14 @@
 // These settings override both User and Default settings for the Markdown syntax
 {
+    // https://packagecontrol.io/packages/MarkdownLight
+    "color_scheme": "Packages/MarkdownLight/MarkdownDark.tmTheme",
+
     // set vertical rulers in specified columns.
     // Use "rulers": [80] for just one ruler
     // default value is []
-    "rulers": [80],
+    "rulers": [],
 
     // turn on word wrap for source and text
     // default value is "auto", which means off for source and on for text
-    "word_wrap": "auto",
-
-    // set word wrapping at this column
-    // default value is 0, meaning wrapping occurs at window width
-    "wrap_width": 0
+    "word_wrap": false,
 }

--- a/roles/apps/sublime-text/files/Package Control.sublime-settings
+++ b/roles/apps/sublime-text/files/Package Control.sublime-settings
@@ -1,15 +1,16 @@
 {
-    "bootstrapped": true,
-    "in_process_packages":
-    [
-    ],
-    "installed_packages":
-    [
-        "Anaconda",
-        "GitGutter",
-        "Package Control",
-        "SideBarEnhancements",
-        "sublack",
-        "Theme - Flatland"
-    ]
+	"bootstrapped": true,
+	"in_process_packages":
+	[
+	],
+	"installed_packages":
+	[
+		"Anaconda",
+		"GitGutter",
+		"MarkdownLight",
+		"Package Control",
+		"SideBarEnhancements",
+		"sublack",
+		"Theme - Flatland"
+	]
 }

--- a/roles/apps/sublime-text/files/Python.sublime-settings
+++ b/roles/apps/sublime-text/files/Python.sublime-settings
@@ -2,5 +2,5 @@
 {
     // Columns in which to display vertical rulers
     "rulers": [88],
-    "sublack.black_on_save": true
+    // "sublack.black_on_save": true
 }


### PR DESCRIPTION
25729515d3b51253ef635e23fdf5584830460578 — **sublime: Don't run Black on save for Python files**

---

e1d6bcd5a439d1ccb9dc71b1d52ff0b88b1b7f95 — **sublime: Rework Markdown file preferences**

This commit installs a new package, MarkdownLight, which adds pretty
Markdown rendering in Sublime Text 3. So nice!

It also drops the rulers and other things that don't make sense when you
write documents as one sentence per line.