### PR TITLE
bash: Use system bash_completions.d directory

### DIFF
--- a/roles/apps/base-workstation/tasks/main.yml
+++ b/roles/apps/base-workstation/tasks/main.yml
@@ -30,4 +30,4 @@
     path: "{{ user_home_dir }}/{{ item }}"
     state: absent
   loop:
-    - .bash_completion.d/task.sh
+    - .bash_completion.d/

--- a/roles/apps/bash/files/bashrc
+++ b/roles/apps/bash/files/bashrc
@@ -23,17 +23,6 @@ export HISTIGNORE="exit:gitst:history:ls:lsa"
 ### append instead of overwriting history file
 shopt -s histappend
 
-## -- source all shell auto-completion definition files ----
-if [ -x "$PATH/poetry" ]; then
-    source $HOME/.bash_completion.d/poetry.bash-completion
-fi
-if [ -x "$PATH/task" ]; then
-    source $HOME/.bash_completion.d/task.bash-completion
-fi
-if [ -x "$PATH/wp" ]; then
-    source $HOME/.bash_completion.d/wp-completion.bash
-fi
-
 ## -- powerline-go configuration ---------------------------
 ### https://github.com/justjanne/powerline-go
 function _update_ps1() {

--- a/roles/apps/bash/tasks/main.yml
+++ b/roles/apps/bash/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: create user bash_completion.d directory
+- name: set permissions on system bash_completion.d directory
   file:
     state: directory
-    path: "{{ user_home_dir }}/.bash_completion.d"
-    group: "{{ target_user }}"
-    owner: "{{ target_user }}"
-    mode: 0750
+    path: "/etc/bash_completion.d"
+    mode: 0755
+    serole: object_r
+    setype: etc_t
     seuser: system_u
 
 - name: copy bashrc and bash_profile
@@ -20,13 +20,13 @@
     - bashrc
     - bash_profile
 
-- name: copy user Bash auto-completion scripts
+- name: copy user Bash auto-completion scripts to system directory
   copy:
     src: "{{ role_path }}/files/{{ item }}"
-    dest: "{{ user_home_dir }}/.bash_completion.d/{{ item }}"
-    group: "{{ target_user }}"
-    owner: "{{ target_user }}"
-    mode: 0444
+    dest: "/etc/bash_completion.d/{{ item }}"
+    mode: 0644
+    serole: object_r
+    setype: etc_t
     seuser: system_u
   loop:
     - poetry.bash-completion


### PR DESCRIPTION
This commit changes behavior for my Bash auto-completion files. The
directory at `~/.bash_completions.d` is not a default path for Bash
auto-completions. Adding the files into `/etc/bash_completions.d` caused
an instant change in auto-completion in a new shell. Instead of trying
to hack this together, this commit uses the system directory for loading
these files into the shell.

It also purges the old directory from the home directory and cleans up
the old `source` commands in my `bashrc` file.