### PR TITLE
bash: Add `grap` search alias

### DIFF
--- a/roles/apps/bash/files/bashrc
+++ b/roles/apps/bash/files/bashrc
@@ -101,3 +101,8 @@ alias gitd6='git dammit6'
 alias gitd7='git dammit7'
 alias gitd8='git dammit8'
 alias gitd9='git dammit9'
+
+## -- aliases: miscellaneous -------------------------------
+
+# $1 is directory, $2 is expression
+function grap { grep -rnw $1 -e "$2"; }


### PR DESCRIPTION
This commit adds a search alias I have long thought about but never got
around to adding until now. It is an expansion of my `grepper` alias,
except it will run a recursive grep on the specified directory and then
with the provided expression.

Example:

```sh
cd ~/
grap wkspc/ "import cntnr"
```

I also checked that this binary is not yet taken in the Fedora
repositories. :eyes: `dnf provides /usr/bin/grap`