### PR TITLE
ripright: Add container-based workaround with F29

### DIFF
--- a/misc/.dockerignore
+++ b/misc/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+Ambiguous/

--- a/misc/ripright/Dockerfile.ripright-multi
+++ b/misc/ripright/Dockerfile.ripright-multi
@@ -1,0 +1,14 @@
+FROM registry.fedoraproject.org/fedora:29
+LABEL maintainer "Justin W. Flory <jflory7+dockerfile@gmail.com>"
+
+WORKDIR /app
+VOLUME /app
+VOLUME /dev/cdrom
+
+RUN dnf upgrade -y --refresh \
+        && dnf install -y ripright \
+        && dnf clean all
+
+COPY ripright_entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["multi"]

--- a/misc/ripright/Dockerfile.ripright-single
+++ b/misc/ripright/Dockerfile.ripright-single
@@ -1,0 +1,16 @@
+#TODO Export files into Docker volume instead of /root/Music
+
+FROM registry.fedoraproject.org/fedora:29
+LABEL maintainer "Justin W. Flory <jflory7+dockerfile@gmail.com>"
+
+WORKDIR /app
+VOLUME /app
+VOLUME /dev/cdrom
+
+RUN dnf upgrade -y --refresh \
+        && dnf install -y ripright \
+        && dnf clean all
+
+COPY ripright_entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["single"]

--- a/misc/ripright/build_containers.sh
+++ b/misc/ripright/build_containers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+#
+# Build Fedora 29 containers with Ripright using Podman/Buildah.
+
+DATE=$(date +%Y-%m-%d)
+PODMAN_BUILD="sudo podman build"
+PODMAN_TAG="sudo podman tag"
+
+logger -s -p user.info -t $0 "Building ripright-single:$DATE..."
+$PODMAN_BUILD -f Dockerfile.ripright-single -t ripright-single:$DATE .
+$PODMAN_TAG ripright-single:$DATE ripright-single:latest
+
+logger -s -p user.info -t $0 "Building ripright-multi:$DATE..."
+$PODMAN_BUILD -f Dockerfile.ripright-multi -t ripright-multi:$DATE .
+$PODMAN_TAG ripright-multi:$DATE ripright-multi:latest

--- a/misc/ripright/import_cd.sh
+++ b/misc/ripright/import_cd.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+#
+# $0 is a script name,
+# $1, $2, $3 etc are passed arguments
+# $1 is our command
+
+export BASE_CMD="sudo podman run --privileged -v $HOME/wkspc/:/root/Music/:z -v /dev/sr1:/dev/cdrom:Z --rm -it"
+CMD=$1
+
+echo -e '\nsudo password required to reset user ownership of $HOME/wkspc\n'
+sudo chown -R $USER:$USER $HOME/wkspc
+case "$CMD" in
+    # Releases with a single match in MusicBrainz database
+  "single" )
+    $BASE_CMD ripright-single
+    chown -R $USER:$USER $HOME/wkspc
+    ;;
+
+    # Releases with multiple matches in MusicBrainz database
+  "multi" )
+    $BASE_CMD ripright-multi
+    chown -R $USER:$USER $HOME/wkspc
+    ;;
+
+   * )
+    exec $CMD ${@:2}
+    ;;
+esac

--- a/misc/ripright/ripright_entrypoint.sh
+++ b/misc/ripright/ripright_entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+#
+# Original credit: Jakub Skałecki
+#   https://rock-it.pl/how-to-write-excellent-dockerfiles/
+#
+# $0 is a script name,
+# $1, $2, $3 etc are passed arguments
+# $1 is our command
+CMD=$1
+
+case "$CMD" in
+    # Releases with a single match in MusicBrainz database
+  "single" )
+    exec ripright -o "%b/%D/%N %T.flac" &
+    ;;
+
+    # Releases with multiple matches in MusicBrainz database
+  "multi" )
+    exec ripright -a -o "%b/%D/%N %T.flac" &
+    ;;
+
+   * )
+    exec $CMD ${@:2}
+    ;;
+esac


### PR DESCRIPTION
This commit adds two new Dockerfiles with instructions to build Fedora
29 containers with the `ripright` package installed. The `ripright`
package was orphaned and subsequently abandoned in Fedora starting in
Fedora 30. The newer gcc version was incompatible with ripright. The two
Dockerfiles represent a clever workaround by creating a F29 container,
mounting a physical CD/DVD drive into the container, and ripping the
contents of a CD from a container to the host system.

Neat-o!

Right now, this might not work fully as expected because of on-going
development in rootless containers. The intention is to run this without
root or any superuser permissions required. Since Podman's rootless
containers use Linux kernel user namespaces, this should be possible at
some point.