### PR TITLE
docs: Add ansible_python_interpreter variable to CentOS

### DIFF
--- a/docs/how-to-use.adoc
+++ b/docs/how-to-use.adoc
@@ -35,5 +35,5 @@ ansible-playbook -K playbooks/rhel-workstation.yml
 
 [source,bash]
 ----
-ansible-playbook playbooks/centos-server.yml
+ansible-playbook -e "ansible_python_interpreter=/usr/bin/python2.7" playbooks/centos-server.yml
 ----


### PR DESCRIPTION
It's annoying, but I cannot set this as an inventory group variable. It
only seems to work when passed in the command-line as part of the
playbook run. :woman_shrugging: