### PR TITLE
Add Google Cloud SDK app role

### DIFF
--- a/playbooks/fedora-workstation.yml
+++ b/playbooks/fedora-workstation.yml
@@ -9,6 +9,7 @@
     - { role: system/packaging-tools, tags: ['packaging-tools', 'system'] }
     - { role: apps/bash, tags: ['bash', 'apps'] }
     - { role: apps/dunst, tags: ['dunst', 'apps'] }
+    - { role: apps/gcloud-sdk, tags: ['google-cloud', 'devops', 'apps'] }
     - { role: apps/git, tags: ['git', 'apps'] }
     - { role: apps/i3wm, tags: ['i3wm', 'apps'] }
     - { role: apps/minecraft, apps: ['minecraft', 'desktop', 'apps'] }

--- a/playbooks/rhel-workstation.yml
+++ b/playbooks/rhel-workstation.yml
@@ -9,6 +9,7 @@
     # - { role: system/packaging-tools, tags: ['packaging-tools', 'system'] }
     - { role: apps/bash, tags: ['bash', 'apps'] }
     # - { role: apps/dunst, tags: ['dunst', 'apps'] }
+    - { role: apps/gcloud-sdk, tags: ['google-cloud', 'devops', 'apps'] }
     - { role: apps/git, tags: ['git', 'apps'] }
     - { role: apps/i3wm, tags: ['i3wm', 'apps'] }
     - { role: apps/npm, tags: ['npm', 'apps'] }

--- a/roles/apps/gcloud-sdk/files/google-cloud-sdk.repo
+++ b/roles/apps/gcloud-sdk/files/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/roles/apps/gcloud-sdk/tasks/main.yml
+++ b/roles/apps/gcloud-sdk/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: import Google repository signing keys
+  rpm_key: key={{ item }} state=present
+  loop:
+    - https://packages.cloud.google.com/yum/doc/yum-key.gpg
+    - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+
+- name: install google-cloud-sdk repository file
+  copy:
+    src: google-cloud-sdk.repo
+    dest: /etc/yum.repos.d/google-cloud-sdk.repo
+    mode: 0644
+    setype: system_conf_t
+    seuser: system_u
+
+- name: install/upgrade google-cloud-sdk
+  package:
+    name: google-cloud-sdk
+    state: latest
+
+- name: install kubectl
+  package:
+    name: kubectl
+    state: present


### PR DESCRIPTION
This commit adds an Ansible Role for the @Google Cloud SDK per the
documentation provided here:

https://cloud.google.com/sdk/docs/#rpm

This works on Fedora 31 and theoretically, CentOS/RHEL 7 and 8.

Part of #18. This will enable me to start using Google Cloud Storage as
a data backend for Restic.