### PR TITLE
Add two new types of role tags: terminal/desktop

### DIFF
--- a/playbooks/centos-server.yml
+++ b/playbooks/centos-server.yml
@@ -6,9 +6,9 @@
   roles:
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/centos-server, tags: ['centos', 'system'] }
-    - { role: apps/bash, tags: ['bash', 'apps'] }
-    - { role: apps/git, tags: ['git', 'apps'] }
-    - { role: apps/powerline-go, tags: ['powerline', 'apps'] }
-    - { role: apps/ssh, tags: ['ssh', 'apps'] }
-    - { role: apps/tmux, tags: ['tmux', 'apps'] }
-    - { role: apps/vim, tags: ['vim', 'apps'] }
+    - { role: apps/bash, tags: ['bash', 'terminal', 'apps'] }
+    - { role: apps/git, tags: ['git', 'terminal', 'apps'] }
+    - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
+    - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
+    - { role: apps/tmux, tags: ['tmux', 'terminal', 'apps'] }
+    - { role: apps/vim, tags: ['vim', 'terminal', 'apps'] }

--- a/playbooks/fedora-workstation.yml
+++ b/playbooks/fedora-workstation.yml
@@ -7,18 +7,18 @@
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/fedora-workstation, tags: ['fedora', 'system'] }
     - { role: system/packaging-tools, tags: ['packaging-tools', 'system'] }
-    - { role: apps/bash, tags: ['bash', 'apps'] }
-    - { role: apps/dunst, tags: ['dunst', 'apps'] }
+    - { role: apps/bash, tags: ['bash', 'terminal', 'apps'] }
+    - { role: apps/dunst, tags: ['dunst', 'desktop', 'apps'] }
     - { role: apps/gcloud-sdk, tags: ['google-cloud', 'devops', 'apps'] }
-    - { role: apps/git, tags: ['git', 'apps'] }
-    - { role: apps/i3wm, tags: ['i3wm', 'apps'] }
+    - { role: apps/git, tags: ['git', 'terminal', 'apps'] }
+    - { role: apps/i3wm, tags: ['i3wm', 'desktop', 'apps'] }
     - { role: apps/minecraft, apps: ['minecraft', 'desktop', 'apps'] }
-    - { role: apps/npm, tags: ['npm', 'apps'] }
-    - { role: apps/powerline-go, tags: ['powerline', 'apps'] }
+    - { role: apps/npm, tags: ['npm', 'terminal', 'apps'] }
+    - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
     - { role: apps/slack, tags: ['slack', 'desktop', 'apps'] }
-    - { role: apps/ssh, tags: ['ssh', 'apps'] }
+    - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
     - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }
     - { role: apps/thunderbird, tags: ['thunderbird', 'desktop', 'apps'] }
-    - { role: apps/tmux, tags: ['tmux', 'apps'] }
-    - { role: apps/tor, tags: ['tor', 'apps'] }
-    - { role: apps/vim, tags: ['vim', 'apps'] }
+    - { role: apps/tmux, tags: ['tmux', 'terminal', 'apps'] }
+    - { role: apps/tor, tags: ['tor', 'desktop', 'apps'] }
+    - { role: apps/vim, tags: ['vim', 'terminal', 'apps'] }

--- a/playbooks/rhel-workstation.yml
+++ b/playbooks/rhel-workstation.yml
@@ -7,16 +7,16 @@
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/rhel-workstation, tags: ['rhel', 'system'] }
     # - { role: system/packaging-tools, tags: ['packaging-tools', 'system'] }
-    - { role: apps/bash, tags: ['bash', 'apps'] }
-    # - { role: apps/dunst, tags: ['dunst', 'apps'] }
+    - { role: apps/bash, tags: ['bash', 'terminal', 'apps'] }
+    # - { role: apps/dunst, tags: ['dunst', 'desktop', 'apps'] }
     - { role: apps/gcloud-sdk, tags: ['google-cloud', 'devops', 'apps'] }
-    - { role: apps/git, tags: ['git', 'apps'] }
-    - { role: apps/i3wm, tags: ['i3wm', 'apps'] }
-    - { role: apps/npm, tags: ['npm', 'apps'] }
-    - { role: apps/powerline-go, tags: ['powerline', 'apps'] }
-    - { role: apps/ssh, tags: ['ssh', 'apps'] }
+    - { role: apps/git, tags: ['git', 'terminal', 'apps'] }
+    - { role: apps/i3wm, tags: ['i3wm', 'desktop', 'apps'] }
+    - { role: apps/npm, tags: ['npm', 'terminal', 'apps'] }
+    - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
+    - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
     - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }
-    # - { role: apps/thunderbird, tags: ['thunderbird', 'apps'] }
-    - { role: apps/tmux, tags: ['tmux', 'apps'] }
-    # - { role: apps/tor, tags: ['tor', 'apps'] }
-    - { role: apps/vim, tags: ['vim', 'apps'] }
+    # - { role: apps/thunderbird, tags: ['thunderbird', 'desktop', 'apps'] }
+    - { role: apps/tmux, tags: ['tmux', 'terminal', 'apps'] }
+    # - { role: apps/tor, tags: ['tor', 'desktop', 'apps'] }
+    - { role: apps/vim, tags: ['vim', 'terminal', 'apps'] }


### PR DESCRIPTION
This commit expands role tags used in playbook so I can choose to run
all of my apps that are for terminal applications (e.g.
`ansible-playbook -t terminal playbooks/master.yml`) and have it run
across all of my environment at once.

Just a little more housekeeping work.