### PR TITLE
system/base: Purge mediawriter package

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -25,6 +25,7 @@
       - gnome-system-monitor
       - gnome-weather
       - logwatch
+      - mediawriter
       - mosh
       - powerline
       - ntp


### PR DESCRIPTION
The Fedora Media Writer is sadly not up to par as a desktop-independent
application. It relies heavily on Qt bindings, almost as if written by
KDE developers. It's not pleasant to use and the UI freezes for random
intervals of time. For now, I'll stick with `dd`... :woman_shrugging: