### PR TITLE
system/python: Absorb poetry installation

### DIFF
--- a/roles/apps/bash/tasks/main.yml
+++ b/roles/apps/bash/tasks/main.yml
@@ -4,7 +4,6 @@
     state: directory
     path: "/etc/bash_completion.d"
     mode: 0755
-    serole: object_r
     setype: etc_t
     seuser: system_u
 
@@ -19,14 +18,3 @@
   loop:
     - bashrc
     - bash_profile
-
-- name: copy user Bash auto-completion scripts to system directory
-  copy:
-    src: "{{ role_path }}/files/{{ item }}"
-    dest: "/etc/bash_completion.d/{{ item }}"
-    mode: 0644
-    serole: object_r
-    setype: etc_t
-    seuser: system_u
-  loop:
-    - poetry.bash-completion

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -92,7 +92,6 @@
       - picard
       - planner
       - podman
-      - poetry
       - poppler-utils
       - powerline-fonts
       - pulseaudio-utils

--- a/roles/system/python/tasks/main.yml
+++ b/roles/system/python/tasks/main.yml
@@ -33,17 +33,29 @@
     name: python-flake8
   when: (ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "RedHat")
 
-- name: (Fedora) install/upgrade pipenv
+- name: (Fedora) install/upgrade pipenv, poetry
   package:
     state: latest
-    name: pipenv
+    name:
+      - pipenv
+      - poetry
   when: ansible_facts['distribution'] == "Fedora"
 
-- name: (CentOS/RedHat) install/upgrade pipenv via pip
+- name: (CentOS/RedHat) install/upgrade pipenv, poetry (via pip)
   become_user: "{{ target_user }}"
   pip:
     executable: pip3
     state: latest
     extra_args: "--user"
-    name: pipenv
+    name:
+      - pipenv
+      - poetry
   when: (ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "RedHat")
+
+- name: copy poetry Bash auto-completion script to /etc/bash_completion.d/
+  copy:
+    src: poetry.bash-completion
+    dest: "/etc/bash_completion.d/poetry.bash-completion"
+    mode: 0644
+    setype: etc_t
+    seuser: system_u


### PR DESCRIPTION
This commit moves the various flibber-flabber for installing the Poetry
Python project management tool out of various other roles and into the
`system/python` role. This is a more natural home for a tool
deliberately made for Python packaging.