### PR TITLE
Miscellaneous hardening and polish

### DIFF
--- a/roles/apps/bash/tasks/main.yml
+++ b/roles/apps/bash/tasks/main.yml
@@ -11,9 +11,10 @@
   copy:
     src: "{{ role_path }}/files/{{ item }}"
     dest: "{{ user_home_dir }}/.{{ item }}"
-    group: "{{ target_user }}"
+    group: "{{ target_group }}"
     owner: "{{ target_user }}"
     mode: 0444
+    setype: config_home_t
     seuser: system_u
   loop:
     - bashrc

--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -27,6 +27,7 @@
       - logwatch
       - mediawriter
       - mosh
+      - origin-clients
       - powerline
       - ntp
       - task


### PR DESCRIPTION
This PR contains two commits with relatively minor changes:

---

93bc3ceabbdb6f3e3adebfa6b1220c8b59bf90be — :lock: **bash: Narrow down setype context, swap target_group in**

I decided to change the `setype` to match the mappings of files and
directories in `~/.config/`. Since these files are at the root of the
home directory, they are not labeled as such, but there is no reason why
they shouldn't be.

Also, this swaps one more `group` from `target_user` to `target_group`.
Huzzah for gradually resolving technical debt!

---

ffc19d83b001b942fec5932f214730d43d06a41d — :package: **system/base: Purge origin-clients to reclaim kubectl**

This commit removes the `origin-clients` package from the base system.
As I found out on my laptop, this conflicts with the `kubectl` package
provided by the `google-cloud-sdk` repository. Oops! Perhaps one day
Google, Kubernetes, Red Hat, and OpenShift will all play together
nicely. For now… :woman_shrugging:

---