### PR TITLE
protonvpn: Add new role

### DIFF
--- a/playbooks/centos-server.yml
+++ b/playbooks/centos-server.yml
@@ -10,6 +10,7 @@
     - { role: apps/bash, tags: ['bash', 'terminal', 'apps'] }
     - { role: apps/git, tags: ['git', 'terminal', 'apps'] }
     - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
+    - { role: apps/protonvpn, tags: ['protonvpn', 'terminal', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
     - { role: apps/tmux, tags: ['tmux', 'terminal', 'apps'] }
     - { role: apps/vim, tags: ['vim', 'terminal', 'apps'] }

--- a/playbooks/fedora-workstation.yml
+++ b/playbooks/fedora-workstation.yml
@@ -16,6 +16,7 @@
     - { role: apps/minecraft, apps: ['minecraft', 'desktop', 'apps'] }
     - { role: apps/npm, tags: ['npm', 'terminal', 'apps'] }
     - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
+    - { role: apps/protonvpn, tags: ['protonvpn', 'terminal', 'apps'] }
     - { role: apps/slack, tags: ['slack', 'desktop', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
     - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }

--- a/playbooks/rhel-workstation.yml
+++ b/playbooks/rhel-workstation.yml
@@ -15,6 +15,7 @@
     - { role: apps/i3wm, tags: ['i3wm', 'desktop', 'apps'] }
     - { role: apps/npm, tags: ['npm', 'terminal', 'apps'] }
     - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
+    - { role: apps/protonvpn, tags: ['protonvpn', 'terminal', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }
     - { role: apps/sublime-text, tags: ['sublime-text', 'desktop', 'apps'] }
     # - { role: apps/thunderbird, tags: ['thunderbird', 'desktop', 'apps'] }

--- a/roles/apps/protonvpn/tasks/main.yml
+++ b/roles/apps/protonvpn/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: install Fedora COPR plugin
+  package:
+    state: present
+    name: dnf-command(copr)
+
+- name: install jflory7/protonvpn-cli COPR repository (via dnf command)
+  command: "dnf -y copr enable jflory7/protonvpn-cli"
+  args:
+    creates: "/etc/yum.repos.d/_copr:copr.fedorainfracloud.org:jflory7:protonvpn-cli.repo"
+
+- name: install protonvpn-cli
+  package:
+    state: present
+    name: protonvpn-cli


### PR DESCRIPTION
This commit adds a new role for @ProtonVPN's command-line client:

https://github.com/ProtonVPN/protonvpn-cli-ng

It isn't that complex. I packaged the Python package into a Fedora COPR
repository for easier installation. Eventually I will work on getting it
packaged into Fedora/EPEL proper, but for now, this lets me start using
ProtonVPN across my environments.