### PR TITLE
system/base: Install custom /etc/hosts file

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -90,3 +90,12 @@
     dest: "{{ user_home_dir }}/git/swiss-army"
     update: no
     version: HEAD
+
+- name: install custom /etc/hosts file from someonewhocares.org
+  get_url:
+    url: https://someonewhocares.org/hosts/zero/hosts
+    dest: /etc/hosts
+    force: yes
+    mode: 0644
+    setype: net_conf_t
+    seuser: system_u


### PR DESCRIPTION
This commit adds a custom `/etc/hosts` file to all of my personal
systems. This improves privacy and security by blocking multiple
malicious and dangerous sites by redirecting them to `localhost`. They
simply never load.