### PR TITLE
protonvpn: Add passwordless sudoers rule

### DIFF
--- a/roles/apps/protonvpn/files/10_protonvpn
+++ b/roles/apps/protonvpn/files/10_protonvpn
@@ -1,0 +1,2 @@
+## Allows members of the users group to run protonvpn commands as root
+%wheel	ALL=NOPASSWD: /usr/bin/protonvpn

--- a/roles/apps/protonvpn/tasks/main.yml
+++ b/roles/apps/protonvpn/tasks/main.yml
@@ -13,3 +13,13 @@
   package:
     state: present
     name: protonvpn-cli
+
+- name: push sudoers.d rule file for protonvpn (wheel group only)
+  copy:
+    src: 10_protonvpn
+    dest: "/etc/sudoers.d/10_protonvpn"
+    owner: root
+    group: root
+    mode: 0640
+    setype: etc_t
+    seuser: system_u


### PR DESCRIPTION
This commit adds a file to be dropped in at /etc/sudoers.d/10_protonvpn
for passwordless `sudo` for any users belonging to the `wheel` group. In
simple terms, this commit lets me run `sudo protonvpn` without typing my
password. Because I do run this command all the time. :scream:

Thanks to the manpages:

    https://www.sudo.ws/man/1.8.15/sudoers.man.html