### PR TITLE
ssh: Update Fedora hosts

### DIFF
--- a/roles/apps/ssh/files/config
+++ b/roles/apps/ssh/files/config
@@ -10,17 +10,9 @@ Host fedorapeople
   HostName fedorapeople.org
   User jflory7
   ProxyCommand ssh -W %h:%p bastion.fedoraproject.org
-Host happinesspackets
-  HostName happinesspackets.fedorainfracloud.org
-  User root
-  ProxyCommand ssh -W %h:%p bastion.fedoraproject.org
-Host happinesspackets-stg
-  HostName happinesspackets-stg.fedorainfracloud.org
-  User root
-  ProxyCommand ssh -W %h:%p bastion.fedoraproject.org
 Host ircfedora
-  Hostname telegram-irc.fedorainfracloud.org
-  User jflory
+  Hostname telegram-irc-01.fedorainfracloud.org
+  User fedora
   ProxyCommand ssh -W %h:%p bastion.fedoraproject.org
 
 # HOSTS: Personal


### PR DESCRIPTION
* Drop fedorahappiness hosts, as they no longer exist
* Update TeleIRC host to new hostname and user