### PR TITLE
system/fedora: Add shotwell to base package set

### DIFF
--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -33,6 +33,7 @@
   # meld: Visual diff and merge tool
   # network-manager-applet: Network control / status applet for NetworkManager
   # remmina: Remote Desktop client
+  # shotwell: Photo organizer and editor
   # poppler-utils: Command line utilities for converting PDF files
   # udftools: FS formatting tools (Universal Disk Format)
   package:
@@ -97,6 +98,7 @@
       - pulseaudio-utils
       - remmina
       - rpmconf
+      - shotwell
       - smartmontools
       - spotify-client
       - strace


### PR DESCRIPTION
So, in an unexpected turn of events, it looks like GNOME Shotwell is
still being actively developed, with some support from the Software
Freedom Conservancy. A while ago, I remember Shotwell was going to be
dropped from Fedora because a new tool was going to replace it. Which
made me sad because Shotwell is the minimal tool I always liked for
making quick photo edits.

But alas, it is being actively maintained in upstream GNOME and it is
currently packaged for Fedora. So I'm going to formally adopt it into my
base package set. :tada: