### PR TITLE
system/{base,fedora}: Swap cmus with lollypop

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -7,6 +7,7 @@
   package:
     state: absent
     name:
+      - cmus
       - evolution
       - evolution-ews
       - evolution-help

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -25,7 +25,6 @@
   ### Package notes ###
   # Fedora packaging tools: fedora-packager, fedpkg, copr-cli
   # chromaprint-tools: Capture digital fingerprints of audio files
-  # cmus: ncurses-based music player
   # exfat-utils: FS formatting tools (exFAT)
   # f2fs-tools: FS formatting tools (Flash-Friendly File System)
   # gstreamer1-plugins-bad-nonfree: MPEG2 codec support
@@ -51,7 +50,6 @@
       - buildah
       - chromaprint-tools
       - chromium
-      - cmus
       - docker-compose
       - duply
       - epiphany
@@ -78,6 +76,7 @@
       - jq
       - libvirt
       - libvirt-devel
+      - lollypop
       - meld
       - moby-engine
       - mpris-scrobbler


### PR DESCRIPTION
I gave cmus a shot and it was cool for a while, but Lollypop has really
won me over. It's such a beautiful music player. cmus is cool for a CLI-
based music player, but you lose out on the richness of album artwork
and artist artwork. And y'know… that's really important.

So, bye cmus. It was nice. Hello lollypop.