### PR TITLE
system/fedora: Add gparted to base package set

### DIFF
--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -65,6 +65,7 @@
       - gobby05
       - golang
       - google-roboto-slab-fonts
+      - gparted
       - gstreamer-ffmpeg
       - gstreamer1-plugins-bad-free-extras
       - gstreamer1-plugins-ugly


### PR DESCRIPTION
I just saved two USB drives that I tried fixing with `parted`, `fdisk`,
`mediawriter`, `gnome-disks`, and `dd`. Somehow `gparted` was the only
one of the lot that could actually delete these ghost partitions
floating around on the drives. I am now a happy owner of Linux install
media once again.

What a bizarre issue.