### PR TITLE
system/{base,fedora}: Move subxid provisioning to Fedora role

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -46,22 +46,6 @@
     ssh_key_file: ".ssh/id_ed25519"
     ssh_key_type: ed25519
 
-# gids/uids required for podman rootless mode
-# https://github.com/jwflory/swiss-army/issues/11
-- name: set multiple gids for target user
-  lineinfile:
-    path: "/etc/subgid"
-    regexp: "^{{ target_user }}:"
-    line: "{{ target_user }}:10000:65536"
-    seuser: system_u
-
-- name: set multiple uids for target user
-  lineinfile:
-    path: "/etc/subuid"
-    regexp: "^{{ target_user }}:"
-    line: "{{ target_user }}:10000:65536"
-    seuser: system_u
-
 - name: create misc. workspace directories
   file:
     state: directory

--- a/roles/system/fedora-workstation/tasks/misc.yml
+++ b/roles/system/fedora-workstation/tasks/misc.yml
@@ -4,3 +4,19 @@
     dest: /etc/dnf/dnf.conf
     regexp: '^installonly_limit='
     line: 'installonly_limit=2'
+
+# gids/uids required for podman rootless mode
+# https://github.com/jwflory/swiss-army/issues/11
+- name: set multiple gids for target user
+  lineinfile:
+    path: "/etc/subgid"
+    regexp: "^{{ target_user }}:"
+    line: "{{ target_user }}:10000:65536"
+    seuser: system_u
+
+- name: set multiple uids for target user
+  lineinfile:
+    path: "/etc/subuid"
+    regexp: "^{{ target_user }}:"
+    line: "{{ target_user }}:10000:65536"
+    seuser: system_u


### PR DESCRIPTION
This is interesting. It appears RHEL 8 automatically allocates the
subgids/subuids automatically for Podman. I noticed that all the users
already had the subxids provisioned when I ran the RHEL 8 playbook with
`--check --diff` flags.

Maybe one day I won't need to do this at all. Until then, I'm just
keeping it in my Fedora role.

Related to jwflory/swiss-army#11.