### PR TITLE
system/base: Harden file permissions on directories

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -52,6 +52,7 @@
     path: "{{ user_home_dir }}/{{ item }}"
     group: "{{ target_group }}"
     owner: "{{ target_user }}"
+    mode: 0700
     seuser: system_u
   loop:
     - .ansible/tmp


### PR DESCRIPTION
I noticed recently on fresh Fedora/RHEL installs, most folders in a
user's home directory are set to `0700`. So, I decided to make my
miscellaneous directories follow that precedent. Because honestly it
does make sense, I'd rather not have users in a shared environment
snooping around in my stuff.