### PR TITLE
apps/cups-server: Initial commit

### DIFF
--- a/playbooks/hosts/lucie.yml
+++ b/playbooks/hosts/lucie.yml
@@ -12,6 +12,7 @@
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/rhel-workstation/8, tags: ['rhel', 'system'] }
     - { role: apps/bash, tags: ['bash', 'terminal', 'apps'] }
+    - { role: apps/cups-server, tags: ['cups', 'terminal', 'apps'] }
     - { role: apps/git, tags: ['git', 'terminal', 'apps'] }
     - { role: apps/powerline-go, tags: ['powerline', 'terminal', 'apps'] }
     - { role: apps/ssh, tags: ['ssh', 'terminal', 'apps'] }

--- a/roles/apps/cups-server/tasks/main.yml
+++ b/roles/apps/cups-server/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: install/upgrade cups
+  package:
+    state: latest
+    name:
+      - cups
+      - cups-ipptool
+
+- name: allow ipp/mdns services in firewall
+  firewalld:
+    service: "{{ item }}"
+    permanent: yes
+    immediate: yes
+    state: enabled
+  loop:
+    - ipp
+    - mdns


### PR DESCRIPTION
86e60aca27e4767e4427309d458d6a0cc6f2f596 — :printer: **apps/cups-server: Initial commit**

Adds package set and firewalld rules for cups-server with DNS-SD/mDNS
discovery enabled.

---

5b58e57980fd0679b7f2d0d8824104f05c2a1566 — :printer: **lucie: Add apps/cups-server role to host**