### PR TITLE
playbooks: Refactor vars from role to playbooks

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,6 +1,0 @@
----
-ansible_python_interpreter: /usr/bin/python3
-target_group: jflory
-target_user: jflory
-target_user_name: Justin W. Flory
-user_home_dir: /home/jflory

--- a/playbooks/centos-server.yml
+++ b/playbooks/centos-server.yml
@@ -3,6 +3,13 @@
   hosts: servers_centos
   become: yes
 
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    target_group: jflory
+    target_user: jflory
+    target_user_name: Justin W. Flory
+    user_home_dir: /home/jflory
+
   roles:
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/centos-server, tags: ['centos', 'system'] }

--- a/playbooks/fedora-workstation.yml
+++ b/playbooks/fedora-workstation.yml
@@ -3,6 +3,13 @@
   hosts: workstation
   become: yes
 
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    target_group: jflory
+    target_user: jflory
+    target_user_name: Justin W. Flory
+    user_home_dir: /home/jflory
+
   roles:
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/fedora-workstation, tags: ['fedora', 'system'] }

--- a/playbooks/hosts/lucie.yml
+++ b/playbooks/hosts/lucie.yml
@@ -4,8 +4,10 @@
   become: yes
 
   vars:
+    ansible_python_interpreter: /usr/bin/python3
     target_group: jwf
     target_user: jwf
+    target_user_name: Justin W. Flory
     user_home_dir: /home/jwf
 
   roles:

--- a/playbooks/rhel-workstation.yml
+++ b/playbooks/rhel-workstation.yml
@@ -3,6 +3,13 @@
   hosts: workstation
   become: yes
 
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    target_group: jwf
+    target_user: jwf
+    target_user_name: Justin W. Flory
+    user_home_dir: /home/jwf
+
   roles:
     - { role: system/base, tags: ['base', 'system'] }
     - { role: system/rhel-workstation, tags: ['rhel', 'system'] }

--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: import global variables
-  include_vars:
-    dir: "{{ inventory_dir }}/group_vars/"
-
 - name: remove unused packages
   package:
     state: absent


### PR DESCRIPTION
Previously, there was a set of global variables I defined in
`inventory/group_vars/all.yml`. In my `system/base` role, I had a task
that explicitly imported those variables into the playbook run. This was
used across all of my roles.

As I found out recently, when there was a divergence in those variables,
either for a specific host or a type of host, managing the difference
was difficult. Overriding the variables was only possible by doing so on
the command line. Since that is easy to forget, I knew there must be a
better way.

So now, all of these variables are defined uniquely in each playbook.
Not sure if this is _The Best Possible Way_, but it is certainly better
than it was before. Keeping it this way for now!

Yay paying off personal technical debt.