### PR TITLE
system/rhel8: Adjust base package set (+2, -1)

### DIFF
--- a/roles/system/rhel-workstation/8/tasks/packages.yml
+++ b/roles/system/rhel-workstation/8/tasks/packages.yml
@@ -42,6 +42,7 @@
       - flash-plugin
       - fpaste
       - git
+      - gnome-tweaks
       - golang
       - google-roboto-fonts
       - gparted
@@ -66,11 +67,12 @@
       # - pass
       - pavucontrol
       # - picard
-      - podman
+      # - podman (something is wrong with AppStream, need to figure out later)
       - pulseaudio-utils
       - rpmconf
       - smartmontools
       - strace
+      - thunderbird
       - which
       - xclip
       - youtube-dl


### PR DESCRIPTION
This commit makes some slight adjustments to the RHEL 8 Workstation
system role:

* Add `gnome-tweaks`
* Add `thunderbird`
* Remove `podman`
    * This one is interesting. `podman` is installed by default on RHEL
      8. However, installing or upgrading it via Ansible triggers
      conflicts with different versioned packages of Podman. I know this
      has to do with AppStream/modularity, but not sure how to fix.
      Since Podman isn't critically important right now, I'm just
      commenting it out until I can figure it out later. :shrug: