### PR TITLE
system/base: Set accept_hostkey to true when cloning swiss-army

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -70,6 +70,7 @@
   git:
     repo: "git@github.com:jwflory/swiss-army.git"
     dest: "{{ user_home_dir }}/git/swiss-army"
+    accept_hostkey: yes
     update: no
     version: HEAD
 


### PR DESCRIPTION
Accept the remote hostkey when cloning jwflory/swiss-army. As I
discovered, this task will always fail if a connection to `github.com`
has never happened on the host before. Since this task does _not_ update
the git repo itself and we don't want it to update mid-run if running
locally, usually this task only matters on a first clone.

My most frequent use case here is cloning the git repo on a newly-
provisioned host. Usually this is the first thing I do on the host.
Given this context, I think it is acceptable to set this boolean here
even if it is not technically the most secure thing in the world.