### PR TITLE
system/{fedora,rhel}: Remove vagrant from base package set

### DIFF
--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -105,9 +105,6 @@
       - telegram-desktop
       - typetype-molot-fonts
       - udftools
-      - '@vagrant'
-      - vagrant-doc
-      - vagrant-sshfs
       - '@virtualization'
       - visualboyadvance-m
       - whipper

--- a/roles/system/rhel-workstation/7/tasks/packages.yml
+++ b/roles/system/rhel-workstation/7/tasks/packages.yml
@@ -75,6 +75,5 @@
       - strace
       - sublime-text
       - typetype-molot-fonts
-      # - vagrant
       - which
       - xclip


### PR DESCRIPTION
Vagrant used to be a tool I used more frequently, especially with
testing my Ansible playbooks in VMs. But it is a tedious and annoying
tool to use in my workflow. Plus, I feel like most of its functionality
that I personally need can be replicated in containers. :shrug:

Furthermore, it also installs several rubygem-* packages on my system,
which starts to feel messy as I manage more Ruby dependencies in my
local user installation (see jwflory/swiss-army#79). So, a good ol'
`dnf autoremove vagrant` and `dnf install bsdtar` cleans things up. I
decided not to automate the removal of Vagrant though. I'll do it on a
case-by-case basis.