### PR TITLE
system{base,fedora}: Only remove certain packages on Fedora

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -7,27 +7,16 @@
       - evolution
       - evolution-ews
       - evolution-help
-      - gnome-boxes
-      - gnome-calendar
-      - gnome-characters
       - gnome-classic-session
-      - gnome-contacts
       - gnome-documents
       - gnome-documents-libs
-      - gnome-getting-started-docs
-      - gnome-initial-setup
-      - gnome-maps
-      - gnome-photos
-      - gnome-shell-extension-pomodoro
       - gnome-system-monitor
-      - gnome-weather
       - logwatch
       - mediawriter
       - mosh
       - origin-clients
       - powerline
       - ntp
-      - task
       - tmux-powerline
       - tomahawk
 
@@ -61,8 +50,6 @@
     state: absent
   loop:
     - "{{ user_home_dir }}/.bash_completion.d/"
-    - "{{ user_home_dir }}/.taskrc"
-    - "/etc/bash_completion.d/task.bash-completion"
 
 - name: clone dotfile repository from GitHub
   become: yes

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -21,6 +21,21 @@
     - https://negativo17.org/repos/fedora-flash-plugin.repo
     - https://negativo17.org/repos/fedora-spotify.repo
 
+- name: remove unused packages
+  package:
+    state: absent
+    name:
+      - gnome-boxes
+      - gnome-calendar
+      - gnome-characters
+      - gnome-contacts
+      - gnome-font-viewer
+      - gnome-getting-started-docs
+      - gnome-initial-setup
+      - gnome-maps
+      - gnome-photos
+      - gnome-weather
+
 - name: install base packages
   ### Package notes ###
   # Fedora packaging tools: fedora-packager, fedpkg, copr-cli


### PR DESCRIPTION
The `system/base` role removes a lot of GNOME applications and tools I
don't have a need for. These are typically installed by default on
Fedora and I want them removed. But now I am maintaining RHEL 8 systems
that are primarily GNOME… and I don't want to purge *all* of these
packages anymore.

So I split some things off into the Fedora role for removal only,
instead of being universal in the system/base role. Also I dropped some
packages and other cruft for non-default packages and files long gone
from my system for many moons.