### PR TITLE
system/fedora: Add bat to base package set

### DIFF
--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -39,6 +39,7 @@
 - name: install base packages
   ### Package notes ###
   # Fedora packaging tools: fedora-packager, fedpkg, copr-cli
+  # bat: cat(1) clone with wings
   # chromaprint-tools: Capture digital fingerprints of audio files
   # exfat-utils: FS formatting tools (exFAT)
   # f2fs-tools: FS formatting tools (Flash-Friendly File System)
@@ -57,6 +58,7 @@
       - ansible
       - arandr
       - bash-completion
+      - bat
       - black
       - blueman
       - bpftrace


### PR DESCRIPTION
@Zedjones shared this in `#rit-lug` and I fell in love with it
immediately. Hardly to my surprise, @ignatenkobrain was the last
committer to the repo when I looked at it, which must obviously mean it
is already in Fedora. :smile:

https://github.com/sharkdp/bat