### PR TITLE
system/fedora: Do not ignore errors from Docker service anymore

### DIFF
--- a/roles/system/fedora-workstation/tasks/services.yml
+++ b/roles/system/fedora-workstation/tasks/services.yml
@@ -4,9 +4,6 @@
     name: docker
     state: started
     enabled: yes
-  # On Fedora 31 or later, Docker is broken with CgroupsV2.
-  # https://fedoraproject.org/wiki/Changes/CGroupsV2
-  ignore_errors: yes
 
 - name: start/enable firewalld
   service:


### PR DESCRIPTION
Huzzah! Docker now supports cgroups v2. A recent package update to
`moby-engine` gets this working and implemented on Fedora 31. I was able
to get the Docker daemon to start successfully on my F31 Workstation.

So, going to pay off this tech debt now by allowing a failure to stop
the playbook run, as it rightfully should.