### PR TITLE
system/flatpak: Initial commit

### DIFF
--- a/roles/system/base/tasks/main.yml
+++ b/roles/system/base/tasks/main.yml
@@ -16,6 +16,7 @@
       - mediawriter
       - mosh
       - origin-clients
+      - planner
       - powerline
       - ntp
       - tmux-powerline

--- a/roles/system/fedora-workstation/meta/main.yml
+++ b/roles/system/fedora-workstation/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: system/fedora-workstation
+  author: Justin W. Flory
+  description: Customized Ansible Role for Justin's Fedora Workstation set-up
+  license: BSD-3-Clause
+
+  min_ansible_version: 2.9
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+
+  galaxy_tags:
+    - linux
+    - fedora
+    - desktop
+
+dependencies:
+  - role: system/flatpak

--- a/roles/system/fedora-workstation/tasks/flatpaks.yml
+++ b/roles/system/fedora-workstation/tasks/flatpaks.yml
@@ -1,0 +1,14 @@
+---
+- name: install default flatpaks as user-managed flatpaks
+  flatpak:
+    name: "{{ item }}"
+    state: present
+    method: system
+  loop:
+    - ch.protonmail.protonmail-bridge
+    - com.adobe.Flash-Player-Projector
+    - com.bluejeans.BlueJeans
+    - com.spotify.Client
+    - im.riot.Riot
+    - org.signal.Signal
+    - us.zoom.Zoom

--- a/roles/system/fedora-workstation/tasks/main.yml
+++ b/roles/system/fedora-workstation/tasks/main.yml
@@ -2,4 +2,5 @@
 - include_tasks: misc.yml
 - include_tasks: user-management.yml
 - include_tasks: packages.yml
+- include_tasks: flatpaks.yml
 - include_tasks: services.yml

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -1,25 +1,10 @@
 ---
-- name: import third-party repository signing keys
-  rpm_key: key={{ item }} state=present
-  loop:
-    - https://negativo17.org/repos/RPM-GPG-KEY-slaanesh
-
 - name: add/upgrade RPM Fusion repositories
   package:
     state: latest
     name:
       - https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ fedora_version }}.noarch.rpm
       - https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ fedora_version }}.noarch.rpm
-
-- name: add other third-party repositories
-  get_url:
-    dest: "/etc/yum.repos.d/"
-    url: "{{ item }}"
-    setype: system_conf_t
-    seuser: system_u
-  loop:
-    - https://negativo17.org/repos/fedora-flash-plugin.repo
-    - https://negativo17.org/repos/fedora-spotify.repo
 
 - name: remove unused packages
   package:
@@ -76,7 +61,6 @@
       - feh
       - ffmpeg
       - firewalld
-      - flash-plugin
       - fpaste
       - git
       - gnome-mahjongg
@@ -108,7 +92,6 @@
       - pandoc
       - pavucontrol
       - picard
-      - planner
       - podman
       - poppler-utils
       - powerline-fonts
@@ -117,7 +100,6 @@
       - rpmconf
       - shotwell
       - smartmontools
-      - spotify-client
       - strace
       - telegram-desktop
       - typetype-molot-fonts

--- a/roles/system/flatpak/tasks/main.yml
+++ b/roles/system/flatpak/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: install flatpak
+  package:
+    name: flatpak
+    state: present
+
+- name: add flathub
+  flatpak_remote:
+    name: flathub
+    state: present
+    method: system
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/scripts/rpm_to_flatpak_migration.yml
+++ b/scripts/rpm_to_flatpak_migration.yml
@@ -1,0 +1,47 @@
+---
+- name: gracefully clean up old RPM applications and reinstall as Flatpaks
+  hosts: workstation
+  become: yes
+
+  vars:
+    target_group: jflory
+    target_user: jflory
+    user_home_dir: /home/jflory
+
+  tasks:
+    - name: purge unused RPM repositories
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/etc/yum.repos.d/bluejeans.repo"
+        - "/etc/yum.repos.d/fedora-flash-plugin.repo"
+        - "/etc/yum.repos.d/fedora-spotify.repo"
+
+    - name: purge unused RPM packages
+      package:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - bluejeans
+        - google-talkplugin
+        - protonmail-bridge
+        - riot
+        - spotify-client
+        - spotify-curl
+        - spotify-ffmpeg
+        - zoom
+
+    - name: reinstall most removed software as Flatpaks
+      flatpak:
+        name: "{{ item }}"
+        state: present
+        method: system
+      loop:
+        - ch.protonmail.protonmail-bridge
+        - com.adobe.Flash-Player-Projector
+        - com.bluejeans.BlueJeans
+        - com.spotify.Client
+        - im.riot.Riot
+        - org.signal.Signal
+        - us.zoom.Zoom


### PR DESCRIPTION
This commit adds a new Flatpak role to swiss-army. This Flatpak role
takes over some of the more complex software installation in the
fedora-workstation role. Ultimately, the goal in this change is better
unification for how software that is not very Fedora-friendly to be
managed more easily.

The `system/fedora-workstation` role also gains a dependency on the
`system/flatpak` role. This ensures the Flatpak role is run before the
system role is applied. It's a more declarative and handy way to link
roles together, instead of making my playbooks longer and longer.