### PR TITLE
system/docker: Initial commit

### DIFF
--- a/roles/system/docker/tasks/main.yml
+++ b/roles/system/docker/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: install moby-engine (/usr/bin/docker)
+  package:
+    name: moby-engine
+    state: present
+
+- name: start/enable docker.service
+  service:
+    name: docker.service
+    state: started
+    enabled: yes

--- a/roles/system/fedora-workstation/tasks/packages.yml
+++ b/roles/system/fedora-workstation/tasks/packages.yml
@@ -23,7 +23,6 @@
 
 - name: install base packages
   ### Package notes ###
-  # Fedora packaging tools: fedora-packager, fedpkg, copr-cli
   # bat: cat(1) clone with wings
   # chromaprint-tools: Capture digital fingerprints of audio files
   # exfat-utils: FS formatting tools (exFAT)
@@ -81,7 +80,6 @@
       - libvirt-devel
       - lollypop
       - meld
-      - moby-engine
       - mpris-scrobbler
       - mpv
       - nautilus-dropbox

--- a/roles/system/fedora-workstation/tasks/services.yml
+++ b/roles/system/fedora-workstation/tasks/services.yml
@@ -1,10 +1,4 @@
 ---
-- name: start/enable docker
-  service:
-    name: docker
-    state: started
-    enabled: yes
-
 - name: start/enable firewalld
   service:
     name: firewalld


### PR DESCRIPTION
Split the management of the `moby-engine` package into its own role,
independent of a specific operating system.