### PR TITLE
i3wm: Add PKT time zone (Asia/Karachi) to i3bar

### DIFF
--- a/roles/apps/i3wm/files/i3status.conf
+++ b/roles/apps/i3wm/files/i3status.conf
@@ -16,6 +16,7 @@ order += "tztime chicago"
 order += "tztime rochester"
 order += "tztime utc"
 order += "tztime tirana"
+order += "tztime karachi"
 order += "tztime mumbai"
 order += "tztime melbourne"
 order += "disk /home"
@@ -62,7 +63,7 @@ tztime local {
 
 tztime anaheim {
     timezone = "America/Los_Angeles"
-	format = "%H:%M %Z"		
+	format = "%H:%M %Z"
 }
 
 tztime chicago {
@@ -82,6 +83,11 @@ tztime utc {
 
 tztime tirana {
     timezone = "Europe/Tirane"
+    format = "%H:%M %Z"
+}
+
+tztime karachi {
+    timezone = "Asia/Karachi"
     format = "%H:%M %Z"
 }
 


### PR DESCRIPTION
This commit adds a new time zone to the desktop i3bar. Now featuring PKT
time for Karachi, via `Asia/Karachi` time zone:

```sh
$ timedatectl list-timezones
```

cc: @nasirhm

![Screenshot of i3bar with PKT time zone](https://user-images.githubusercontent.com/4721034/81602416-91e25f80-939a-11ea-9fd8-bece68b9d28f.png "Screenshot of i3bar with PKT time zone")