### PR TITLE
protonvpn: Add systemd service to connect on boot

### DIFF
--- a/roles/apps/protonvpn/tasks/main.yml
+++ b/roles/apps/protonvpn/tasks/main.yml
@@ -20,3 +20,19 @@
     mode: 0640
     setype: etc_t
     seuser: system_u
+
+- name: push systemd unit file to automatically connect on system boot
+  template:
+    src: protonvpn.service
+    dest: /usr/lib/systemd/system/protonvpn.service
+    owner: root
+    group: root
+    mode: 0644
+    setype: systemd_unit_file_t
+    seuser: system_u
+
+- name: start/enable protonvpn.service
+  service:
+    name: protonvpn.service
+    state: started
+    enabled: yes

--- a/roles/apps/protonvpn/templates/protonvpn.service
+++ b/roles/apps/protonvpn/templates/protonvpn.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Automatically connect to a ProtonVPN Secure Core VPN server.
+Wants=network-online.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/protonvpn connect --sc
+Environment=PVPN_WAIT=300
+Environment=PVPN_DEBUG=1
+Environment=SUDO_USER={{ target_user }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Stolen from: https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md#auto-connect-on-boot

This will be a handy way to make sure my web traffic remains mostly
secure as early as possible in the boot-up process.